### PR TITLE
feat: add sales service and integrate with store

### DIFF
--- a/lib/app/modules/client/client_module.dart
+++ b/lib/app/modules/client/client_module.dart
@@ -1,14 +1,20 @@
 import 'package:e_vendas/app/core/model/plano_model.dart';
+import 'package:e_vendas/app/core/stores/global_store.dart';
 import 'package:e_vendas/app/modules/client/pages/client_form_page.dart';
+import 'package:e_vendas/app/modules/sales/services/sales_service.dart';
 import 'package:e_vendas/app/modules/sales/stores/sales_store.dart';
 import 'package:flutter_modular/flutter_modular.dart';
+
 import 'stores/client_store.dart';
 
 class ClientModule extends Module {
   @override
   void binds(i) {
     i.addLazySingleton(ClientStore.new);
-    i.addLazySingleton(SalesStore.new);
+    i.addLazySingleton(SalesService.new);
+    i.addLazySingleton<SalesStore>(
+      () => SalesStore(i.get<SalesService>(), i.get<GlobalStore>()),
+    );
   }
 
 @override

--- a/lib/app/modules/finish_sale/finish_sale_module.dart
+++ b/lib/app/modules/finish_sale/finish_sale_module.dart
@@ -1,12 +1,17 @@
+import 'package:e_vendas/app/core/stores/global_store.dart';
 import 'package:e_vendas/app/modules/finish_sale/page/finish_sale_page.dart';
 import 'package:e_vendas/app/modules/finish_sale/store/finish_sale_store.dart';
+import 'package:e_vendas/app/modules/sales/services/sales_service.dart';
+import 'package:e_vendas/app/modules/sales/stores/sales_store.dart';
 import 'package:flutter_modular/flutter_modular.dart';
-import '../sales/stores/sales_store.dart';
 class FinishSaleModule extends Module {
   @override
   void binds(i) {
     i.addLazySingleton(FinishSaleStore.new);
-    i.addLazySingleton(SalesStore.new);
+    i.addLazySingleton(SalesService.new);
+    i.addLazySingleton<SalesStore>(
+      () => SalesStore(i.get<SalesService>(), i.get<GlobalStore>()),
+    );
   }
 
   @override

--- a/lib/app/modules/plans/plans_module.dart
+++ b/lib/app/modules/plans/plans_module.dart
@@ -1,5 +1,8 @@
+import 'package:e_vendas/app/core/stores/global_store.dart';
+import 'package:e_vendas/app/modules/sales/services/sales_service.dart';
 import 'package:e_vendas/app/modules/sales/stores/sales_store.dart';
 import 'package:flutter_modular/flutter_modular.dart';
+
 import 'pages/plans_page.dart';
 import 'stores/plans_store.dart';
 
@@ -7,7 +10,10 @@ class PlansModule extends Module {
   @override
   void binds(i) {
     i.addLazySingleton(PlansStore.new);
-    i.addLazySingleton(SalesStore.new);
+    i.addLazySingleton(SalesService.new);
+    i.addLazySingleton<SalesStore>(
+      () => SalesStore(i.get<SalesService>(), i.get<GlobalStore>()),
+    );
   }
 
   @override

--- a/lib/app/modules/sales/pages/sales_page.dart
+++ b/lib/app/modules/sales/pages/sales_page.dart
@@ -21,7 +21,7 @@ class _SalesPageState extends State<SalesPage> {
   void initState() {
     super.initState();
     // Dispara a busca de dados do servidor sempre que a tela é iniciada.
-    store.syncOpenProposals();
+    store.fetchVendas();
   }
 
   @override

--- a/lib/app/modules/sales/sales_module.dart
+++ b/lib/app/modules/sales/sales_module.dart
@@ -1,15 +1,21 @@
+import 'package:e_vendas/app/core/stores/global_store.dart';
+import 'package:e_vendas/app/modules/sales/services/sales_service.dart';
 import 'package:flutter_modular/flutter_modular.dart';
+
 import 'pages/sales_page.dart';
 import 'stores/sales_store.dart';
 
 class SalesModule extends Module {
   @override
   void binds(i) {
-    i.addLazySingleton(SalesStore.new);
+    i.addLazySingleton(SalesService.new);
+    i.addLazySingleton<SalesStore>(
+      () => SalesStore(i.get<SalesService>(), i.get<GlobalStore>()),
+    );
   }
 
   @override
   void routes(r) {
-    r.child('/', child: (context) => SalesPage());
+    r.child('/', child: (context) => const SalesPage());
   }
 }

--- a/lib/app/modules/sales/services/sales_service.dart
+++ b/lib/app/modules/sales/services/sales_service.dart
@@ -1,11 +1,92 @@
-// lib/app/modules/finish_sale/repository/proposta_repository.dart
+// lib/app/modules/sales/services/sales_service.dart
 
 import 'package:dio/dio.dart';
 import 'package:e_vendas/app/core/config/api_client.dart';
+import 'package:e_vendas/app/core/model/contato_model.dart';
+import 'package:e_vendas/app/core/model/endereco_model.dart';
+import 'package:e_vendas/app/core/model/pessoa_model.dart';
+import 'package:e_vendas/app/core/model/plano_model.dart';
+import 'package:e_vendas/app/core/model/values_of_ccontract_model.dart';
+import 'package:e_vendas/app/core/model/venda_model.dart';
 
-// O nome da classe foi mantido como SalesService para consistência com o exemplo
+/// Service responsável por operações de vendas
 class SalesService {
   final Dio _dio = ApiClient().dio;
+
+  /// Busca vendas em aberto de um vendedor e mapeia para [VendaModel].
+  Future<List<VendaModel>> fetchOpenSales(int vendedorId) async {
+    try {
+      final response = await _dio.get(
+        '/database/propostas/abertas',
+        queryParameters: {'vendedorId': vendedorId},
+      );
+
+      final data = response.data as List<dynamic>;
+      return data
+          .map((json) => _mapVenda(json as Map<String, dynamic>))
+          .toList();
+    } on DioException catch (e) {
+      throw Exception(_handleDioError(e, 'Erro ao buscar vendas'));
+    } catch (e) {
+      throw Exception('Erro inesperado ao buscar vendas: $e');
+    }
+  }
+
+  /// Converte o JSON da API para [VendaModel], tratando campos divergentes.
+  VendaModel _mapVenda(Map<String, dynamic> json) {
+    final plano = _mapPlan(json['plano'] as Map<String, dynamic>?);
+
+    return VendaModel(
+      plano: plano,
+      pessoaTitular: json['pessoatitular'] != null
+          ? PessoaModel.fromJson(
+              Map<String, dynamic>.from(json['pessoatitular']))
+          : null,
+      pessoaResponsavelFinanceiro: json['pessoaresponsavelfinanceiro'] != null
+          ? PessoaModel.fromJson(
+              Map<String, dynamic>.from(json['pessoaresponsavelfinanceiro']))
+          : null,
+      dependentes: (json['dependentes'] as List<dynamic>? ?? [])
+          .map((e) =>
+              PessoaModel.fromJson(Map<String, dynamic>.from(e)))
+          .toList(),
+      endereco: json['endereco'] != null
+          ? EnderecoModel.fromJson(
+              Map<String, dynamic>.from(json['endereco']))
+          : null,
+      contatos: (json['contatos'] as List<dynamic>? ?? [])
+          .map((e) =>
+              ContatoModel.fromJson(Map<String, dynamic>.from(e)))
+          .toList(),
+    );
+  }
+
+  /// Mapeia o JSON de plano para [PlanModel] preenchendo valores padrão.
+  PlanModel _mapPlan(Map<String, dynamic>? json) {
+    if (json == null) {
+      return PlanModel(
+        id: 0,
+        codigoPlano: '',
+        nroContrato: 0,
+        nomeContrato: '',
+        values: [],
+        vidasSelecionadas: 1,
+      );
+    }
+
+    return PlanModel(
+      id: json['id'] ?? 0,
+      codigoPlano: json['codigo_plano'] ?? json['codigoPlano'] ?? '',
+      nroContrato: json['nro_contrato'] ?? json['nroContrato'] ?? 0,
+      nomeContrato: json['nome_contrato'] ?? json['nomeContrato'] ?? '',
+      values: (json['values'] as List<dynamic>? ?? [])
+          .map((e) => ValuesOfContractModel.fromMap(
+              Map<String, dynamic>.from(e)))
+          .toList(),
+      vidasSelecionadas:
+          json['vidas_selecionadas'] ?? json['vidasSelecionadas'] ?? 1,
+    );
+  }
 
   /// Salva a proposta completa na API
   Future<Response> salvarProposta(Map<String, dynamic> propostaData) async {
@@ -14,40 +95,17 @@ class SalesService {
       final response = await _dio.post(endpoint, data: propostaData);
       return response;
     } on DioException catch (e) {
-      // PADRÃO APLICADO: Lança uma Exception genérica com a mensagem formatada
       throw Exception(_handleDioError(e, 'Erro ao salvar proposta'));
     } catch (e) {
-      // PADRÃO APLICADO: Trata outros erros inesperados
       throw Exception('Erro inesperado ao salvar proposta: $e');
     }
   }
 
-   /// Busca as propostas em aberto de um vendedor no backend.
-  Future<List<dynamic>> getOpenProposals(int vendedorId) async {
-    try {
-      // Usamos o endpoint que criamos no backend
-      final response = await _dio.get(
-        '/database/propostas/abertas',
-        queryParameters: {'vendedorId': 22},
-      );
-      // A API retorna uma lista de JSONs
-      return response.data as List<dynamic>;
-    } on DioException catch (e) {
-      throw Exception(_handleDioError(e, 'Erro ao buscar propostas abertas'));
-    } catch (e) {
-      throw Exception('Erro inesperado ao buscar propostas: $e');
-    }
-  }
-
-
-  /// PADRÃO APLICADO: Helper para tratar e formatar erros do Dio.
-  /// Este método é idêntico ao do seu ClientService.
+  /// Trata e formata erros do Dio
   String _handleDioError(DioException e, String defaultMessage) {
     if (e.response != null && e.response?.data is Map<String, dynamic>) {
-      // Tenta extrair a mensagem específica retornada pela API
       return '$defaultMessage: ${e.response?.data['message'] ?? e.response?.statusMessage}';
     }
-    // Se não houver uma resposta ou mensagem específica, retorna a mensagem padrão.
     return defaultMessage;
   }
 }

--- a/lib/app/modules/sales/stores/sales_store.g.dart
+++ b/lib/app/modules/sales/stores/sales_store.g.dart
@@ -24,6 +24,14 @@ mixin _$SalesStore on _SalesStoreBase, Store {
       super.vendas = value;
     });
   }
+  late final _$fetchVendasAsyncAction =
+      AsyncAction('_SalesStoreBase.fetchVendas', context: context);
+
+  @override
+  Future<void> fetchVendas() {
+    return _$fetchVendasAsyncAction.run(() => super.fetchVendas());
+  }
+
 
   late final _$criarVendaComPlanoAsyncAction =
       AsyncAction('_SalesStoreBase.criarVendaComPlano', context: context);


### PR DESCRIPTION
## Summary
- add SalesService to fetch open sales and map API data
- register SalesService and update SalesStore with injected dependencies
- trigger fetchVendas from SalesPage on init
- ensure SalesStore is bound with GlobalStore across modules

## Testing
- `dart format lib/app/modules/sales/sales_module.dart lib/app/modules/plans/plans_module.dart lib/app/modules/finish_sale/finish_sale_module.dart lib/app/modules/client/client_module.dart` *(failed: command not found)*
- `flutter analyze` *(failed: command not found)*
- `flutter test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b963743fc8320b3015187bb06833b